### PR TITLE
remove login from conversion

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :require_login
+  # before_action :require_login
 
   private
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :require_login, only: %i[top]
+  # skip_before_action :require_login, only: %i[top]
 
   def top; end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,11 +10,7 @@
   </head>
 
   <body>
-    <% if logged_in? %>
-      <%= render 'shared/header' %>
-    <% else %>
-      <%= render 'shared/before_login_header' %>
-    <% end %>
+    <%= render 'shared/header' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
     <%= link_to image_tag("S__22192130.jpg", height: "90"), root_path %>
   </span>
   <span class="header_right">
-    <%= link_to 'ログアウト', logout_path, class: 'header_button', data: { turbo_method: :delete } %>
+    <%# <%= link_to 'ログアウト', logout_path, class: 'header_button', data: { turbo_method: :delete } %> %>
     <%= link_to '変換する', select_language_path, :class => 'header_button' %>
   </span>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,6 +4,6 @@
   </span>
   <span class="header_right">
     <%# <%= link_to 'ログアウト', logout_path, class: 'header_button', data: { turbo_method: :delete } %> %>
-    <%= link_to '変換する', select_language_path, :class => 'header_button' %>
+    <%= link_to '変換言語選択', select_language_path, :class => 'header_button' %>
   </span>
 </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,15 +1,6 @@
-<% if logged_in? %>
-  <div class="main">
-    <div class="top_title">かなバース</div>
-    <div class="top_sub">ひらがなを外国語の文字に換えてみましょう！</div>
-    <%= link_to '変換する', select_language_path, :class => 'top_convert' %>
-  </div>
-<% else %>
-  <div class="main">
-    <div class="top_title">かなバース</div>
-    <div class="top_sub">ひらがなを外国語の文字に換えてみましょう！</div>
-    <%= link_to 'ログイン', login_path, :class => 'top_login' %>
-    <%= link_to '新規登録', new_user_path, :class => 'top_sign_up' %>
-  </div>
-<% end %>
+<div class="main">
+  <div class="top_title">かなバース</div>
+  <div class="top_sub">ひらがなを外国語の文字に換えてみましょう！</div>
+  <%= link_to '変換する', select_language_path, :class => 'top_convert' %>
+</div>
 


### PR DESCRIPTION
概要
変換機能からログイン機能を除きました。
（本リリース時までに追加する予定の機能（クイズ投稿機能など）を利用する際にログインを必要とする予定です。）
ヘッダーの「変換する」ボタンの表示を「変換言語選択」に変更しました。
